### PR TITLE
QA-4139 fix ignite3 clients

### DIFF
--- a/ignite3/src/main/java/site/ycsb/db/ignite3/AbstractSqlClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/AbstractSqlClient.java
@@ -20,7 +20,7 @@ abstract class AbstractSqlClient extends IgniteAbstractClient {
 
     String columnsString = String.join(", ", columns);
     String valuesString = insertValues.stream()
-        .map(e -> "'" + e + "'")
+        .map(e -> "'" + e.replaceAll("'", "''") + "'")
         .collect(Collectors.joining(", "));
 
     return String.format("INSERT INTO %s (%s) VALUES (%s)", table, columnsString, valuesString);

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteClient.java
@@ -16,6 +16,7 @@
  */
 package site.ycsb.db.ignite3;
 
+import java.util.HashSet;
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
 import site.ycsb.StringByteIterator;
@@ -58,7 +59,8 @@ public class IgniteClient extends IgniteAbstractClient {
         return Status.NOT_FOUND;
       }
 
-      if (fields.isEmpty()) {
+      if (fields == null || fields.isEmpty()) {
+        fields = new HashSet<>();
         for (int iter = 0; iter < tValues.columnCount(); iter++) {
           fields.add(tValues.columnName(iter));
         }

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -56,7 +57,8 @@ public class IgniteJdbcClient extends AbstractSqlClient {
           return Status.NOT_FOUND;
         }
 
-        if (fields.isEmpty()) {
+        if (fields == null || fields.isEmpty()) {
+          fields = new HashSet<>();
           fields.addAll(FIELDS);
         }
 

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteSqlClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteSqlClient.java
@@ -1,5 +1,6 @@
 package site.ycsb.db.ignite3;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,7 +55,8 @@ public class IgniteSqlClient extends AbstractSqlClient {
           return Status.NOT_FOUND;
         }
 
-        if (fields.isEmpty()) {
+        if (fields == null || fields.isEmpty()) {
+          fields = new HashSet<>();
           fields.addAll(FIELDS);
         }
 


### PR DESCRIPTION
- fixed Null pointer exception for the `fields` variable on the `read` method. As parameter description `fields` - The list of fields to read, or null for all of them.
- fixed escaping `'` character for the SQL clients for the `prepareInsertStatement` method.