### PR TITLE
fix sql clients

### DIFF
--- a/ignite3/src/main/java/site/ycsb/db/ignite3/AbstractSqlClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/AbstractSqlClient.java
@@ -26,7 +26,7 @@ abstract class AbstractSqlClient extends IgniteAbstractClient {
     return String.format("INSERT INTO %s (%s) VALUES (%s)", table, columnsString, valuesString);
   }
 
-  static String prepareReadStatement(String table, String key) {
-    return String.format("SELECT * FROM %s WHERE %s = '%s'", table, PRIMARY_COLUMN_NAME, key);
+  static String prepareReadStatement(String table) {
+    return String.format("SELECT * FROM %s WHERE %s = ?", table, PRIMARY_COLUMN_NAME);
   }
 }

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteSqlClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteSqlClient.java
@@ -42,18 +42,18 @@ public class IgniteSqlClient extends AbstractSqlClient {
   @Override
   public Status read(String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
     try {
-      String qry = prepareReadStatement(table, key);
+      String qry = prepareReadStatement(table);
 
       if (debug) {
         LOG.info(qry);
       }
 
-      try (ResultSet<SqlRow> rs = session.execute(null, qry)) {
-        SqlRow row = rs.next();
-
-        if (row == null) {
+      try (ResultSet<SqlRow> rs = session.execute(null, qry, key)) {
+        if (!rs.hasNext()) {
           return Status.NOT_FOUND;
         }
+
+        SqlRow row = rs.next();
 
         if (fields == null || fields.isEmpty()) {
           fields = new HashSet<>();


### PR DESCRIPTION
This patch fixes two problems related to sql clients:

- first problem is incorrect test for empty result set inside `IgniteSqlClient`. We have to test result set with `rs.hasNext`, and if result is 'true', issue a next item. Otherwise NoSuchElementException will be thrown
- second problem relates to sql clients in general. Without using sql param, query will be parsed and optimized on every run, thus we can't expect decent performance.