### PR TITLE
QA-4295 [YCSB] Support more than one server host in thin client benchmarks

### DIFF
--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
@@ -62,7 +62,7 @@ public abstract class IgniteAbstractClient extends DB {
 
   protected static final String HOSTS_PROPERTY = "hosts";
 
-  protected static final String PORTS_PROPERTY = "ports";
+  protected static final String DEFAULT_PORT = "10800";
 
   protected static final String PRIMARY_COLUMN_NAME = "yscb_key";
 
@@ -73,9 +73,7 @@ public abstract class IgniteAbstractClient extends DB {
    */
   protected static Ignite node;
 
-  protected static String host;
-
-  protected static String ports;
+  protected static String hosts;
 
   protected static KeyValueView<Tuple, Tuple> kvView;
 
@@ -153,13 +151,12 @@ public abstract class IgniteAbstractClient extends DB {
           FIELDS.add(fieldPrefix + i);
         }
 
-        host = getProperties().getProperty(HOSTS_PROPERTY);
-        if (!useEmbeddedIgnite && host == null) {
+        hosts = getProperties().getProperty(HOSTS_PROPERTY);
+        if (!useEmbeddedIgnite && hosts == null) {
           throw new DBException(String.format(
               "Required property \"%s\" missing for Ignite Cluster",
               HOSTS_PROPERTY));
         }
-        ports = getProperties().getProperty(PORTS_PROPERTY, "10800");
 
         if (useEmbeddedIgnite) {
           initEmbeddedServerNode();
@@ -173,7 +170,7 @@ public abstract class IgniteAbstractClient extends DB {
   }
 
   private void initIgniteClientNode() throws DBException {
-    node = IgniteClient.builder().addresses(host + ":" + ports).build();
+    node = IgniteClient.builder().addresses(hosts.split(",")).build();
     createTestTable(node);
     kvView = node.tables().table(cacheName).keyValueView();
     if (kvView == null) {

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
@@ -30,13 +30,17 @@ public class IgniteJdbcClient extends AbstractSqlClient {
   public void init() throws DBException {
     super.init();
 
-    if (host == null) {
+    if (hosts == null) {
       throw new DBException(String.format(
           "Required property \"%s\" missing for Ignite Cluster",
           HOSTS_PROPERTY));
     }
 
-    String url = "jdbc:ignite:thin://" + host + ":" + ports;
+    if (hosts.contains(",")) {
+      throw new DBException("JDBC supports only 1 server host");
+    }
+
+    String url = "jdbc:ignite:thin://" + hosts + (hosts.contains(":") ? "" : ":" + DEFAULT_PORT);
     try {
       CONN.set(DriverManager.getConnection(url));
     } catch (Exception e) {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/QA-4295

Result examples:
- 1 server
https://ward.gridgain.com/tests/653ba990165f80acb1d409cf
https://ward.gridgain.com/tests/653bac7c165f80acb1d409d9
https://ward.gridgain.com/tests/653baec7165f80acb1d409de

- 3 servers
https://ward.gridgain.com/tests/653ba872165f80acb1d409ca
https://ward.gridgain.com/tests/653bab09165f80acb1d409d4
https://ward.gridgain.com/tests/653bb170165f80acb1d409e3