### PR TITLE
QA-4519 [YCSB] Fix "UNEXPECTED_STATE" for IgniteSqlClient and IgniteJdbcClient

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -72,7 +72,7 @@ LICENSE file.
 
   <profiles>
     <profile>
-      <!-- Build profile when running via yscb.sh or yscb.bat-->
+      <!-- Build profile when running via ycsb.sh or ycsb.bat-->
       <id>source-run</id>
       <build>
         <plugins>

--- a/ignite3/bin/run_emb.sh
+++ b/ignite3/bin/run_emb.sh
@@ -19,7 +19,7 @@ declare -a WORKLOADS=(
 GLOBAL_ARGS=
 #GLOBAL_ARGS="-p operationcount=10 -p recordcount=10 -p debug=true"
 
-function runYscb() {
+function runYcsb() {
   local mode=$1
   local binding=$2
   local logFileName=$3
@@ -53,9 +53,9 @@ function runBinding() {
 
   rm -rf ignite3-work
 
-  runYscb "load" "${binding}" "${logFileName}" "-threads 4"
-  runYscb "run"  "${binding}" "${logFileName}" "-threads 1"
-  runYscb "run"  "${binding}" "${logFileName}" "-threads 4"
+  runYcsb "load" "${binding}" "${logFileName}" "-threads 4"
+  runYcsb "run"  "${binding}" "${logFileName}" "-threads 1"
+  runYcsb "run"  "${binding}" "${logFileName}" "-threads 4"
 }
 
 for binding in "${BINDINGS[@]}"; do

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/AbstractSqlClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/AbstractSqlClient.java
@@ -53,8 +53,8 @@ abstract class AbstractSqlClient extends IgniteAbstractClient {
 
     statement.setString(i++, key);
 
-    for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
-      statement.setString(i++, entry.getValue().toString());
+    for (String fieldName: FIELDS) {
+      statement.setString(i++, values.get(fieldName).toString());
     }
   }
 }

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
@@ -65,7 +65,7 @@ public abstract class IgniteAbstractClient extends DB {
 
   protected static final String DEFAULT_PORT = "10800";
 
-  protected static final String PRIMARY_COLUMN_NAME = "yscb_key";
+  protected static final String PRIMARY_COLUMN_NAME = "ycsb_key";
 
   protected static final String DEFAULT_ZONE_NAME = "Z1";
 

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
@@ -94,7 +94,8 @@ public class IgniteJdbcClient extends AbstractSqlClient {
         }
 
         for (String column : fields) {
-          String val = rs.getString(FIELDS.indexOf(column) + 2); //+2 because indexes start from 1 and 1st one is key field
+          //+2 because indexes start from 1 and 1st one is key field
+          String val = rs.getString(FIELDS.indexOf(column) + 2);
 
           if (val != null) {
             result.put(column, new StringByteIterator(val));

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
@@ -94,7 +94,7 @@ public class IgniteJdbcClient extends AbstractSqlClient {
         }
 
         for (String column : fields) {
-          String val = rs.getString(FIELDS.indexOf(column) + 1);
+          String val = rs.getString(FIELDS.indexOf(column) + 2); //+2 because indexes start from 1 and 1st one is key field
 
           if (val != null) {
             result.put(column, new StringByteIterator(val));

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteSqlClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteSqlClient.java
@@ -96,7 +96,7 @@ public class IgniteSqlClient extends AbstractSqlClient {
       if (table.equals(cacheName)) {
         List<String> valuesList = new ArrayList<>();
         valuesList.add(key);
-        values.values().forEach(v -> valuesList.add(String.valueOf(v)));
+        FIELDS.forEach(fieldName -> valuesList.add(String.valueOf(values.get(fieldName))));
         session.execute(null, insertPreparedStatementString, (Object[]) valuesList.toArray(new String[0])).close();
       } else {
         throw new UnsupportedOperationException("Unexpected table name: " + table);


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/QA-4519

Issue cause:
- `insertPreparedStatementString` has ordered fields enumeration from `FIELDS` variable while `values` provides them as unordered HashMap.

Result examples:
- SQL - https://ward.gridgain.com/tests/659fb7b0565f06dd36244b8a
- JDBC - https://ward.gridgain.com/tests/659fb933565f06dd36244b90