### PR TITLE
QA-4542 [YCSB] Support more than one endpoint in IgniteJdbcClient

### DIFF
--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
@@ -63,8 +63,6 @@ public abstract class IgniteAbstractClient extends DB {
 
   protected static final String HOSTS_PROPERTY = "hosts";
 
-  protected static final String DEFAULT_PORT = "10800";
-
   protected static final String PRIMARY_COLUMN_NAME = "ycsb_key";
 
   protected static final String DEFAULT_ZONE_NAME = "Z1";

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
@@ -63,11 +63,7 @@ public class IgniteJdbcClient extends AbstractSqlClient {
           HOSTS_PROPERTY));
     }
 
-    if (hosts.contains(",")) {
-      throw new DBException("JDBC supports only 1 server host");
-    }
-
-    String url = "jdbc:ignite:thin://" + hosts + (hosts.contains(":") ? "" : ":" + DEFAULT_PORT);
+    String url = "jdbc:ignite:thin://" + hosts;
     try {
       CONN.set(DriverManager.getConnection(url));
     } catch (Exception e) {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/QA-4542

Note: Any of the following JDBC connection lines works well to connect to 3 server nodes cluster:
 - jdbc:ignite:thin://172.24.1.2:10800,172.24.1.3:10800,172.24.1.4:10800
 - jdbc:ignite:thin://172.24.1.2,172.24.1.3,172.24.1.4
 - jdbc:ignite:thin://172.24.1.2,172.24.1.3:10800,172.24.1.4
 - jdbc:ignite:thin://172.24.1.2
 - jdbc:ignite:thin://172.24.1.3
 - jdbc:ignite:thin://172.24.1.4