### PR TITLE
QA-4725 Fix JDBC connection

### DIFF
--- a/ignite/src/main/java/site/ycsb/db/ignite/IgniteJdbcClient.java
+++ b/ignite/src/main/java/site/ycsb/db/ignite/IgniteJdbcClient.java
@@ -118,10 +118,6 @@ public class IgniteJdbcClient extends IgniteAbstractClient {
         hostsStr = hosts;
       }
 
-      //workaround for https://ggsystems.atlassian.net/browse/IGN-23887
-      //use only one cluster node address for connection
-      hostsStr = hostsStr.split(",")[0];
-
       String url = "jdbc:ignite:thin://" + hostsStr;
       try {
         CONN.set(DriverManager.getConnection(url));

--- a/ignite/src/main/java/site/ycsb/db/ignite/IgniteJdbcClient.java
+++ b/ignite/src/main/java/site/ycsb/db/ignite/IgniteJdbcClient.java
@@ -42,7 +42,8 @@ public class IgniteJdbcClient extends IgniteAbstractClient {
   /**
    * Use separate connection per thread since sharing a single Connection object is not recommended.
    */
-  private static final ThreadLocal<Connection> CONN = new ThreadLocal<>();
+  private static final ThreadLocal<Connection> CONN = ThreadLocal
+      .withInitial(IgniteJdbcClient::buildConnection);
 
   /** Prepared statement for reading values. */
   private static final ThreadLocal<PreparedStatement> READ_PREPARED_STATEMENT = ThreadLocal
@@ -62,6 +63,26 @@ public class IgniteJdbcClient extends IgniteAbstractClient {
       return CONN.get().prepareStatement(readPreparedStatementString);
     } catch (SQLException e) {
       throw new RuntimeException("Unable to prepare statement for SQL: " + readPreparedStatementString, e);
+    }
+  }
+
+  /** Build JDBC connection. */
+  private static Connection buildConnection() {
+    String hostsStr;
+
+    if (useEmbeddedIgnite) {
+      Set<String> addrs = new HashSet<>();
+      cluster.cluster().nodes().forEach(clusterNode -> addrs.addAll(clusterNode.addresses()));
+      hostsStr = String.join(",", addrs);
+    } else {
+      hostsStr = hosts;
+    }
+
+    String url = "jdbc:ignite:thin://" + hostsStr;
+    try {
+      return DriverManager.getConnection(url);
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to establish connection with " + url, e);
     }
   }
 
@@ -107,23 +128,6 @@ public class IgniteJdbcClient extends IgniteAbstractClient {
           cacheName, columnsString, valuesString);
 
       deletePreparedStatementString = String.format("DELETE * FROM %s WHERE %s = ?", cacheName, PRIMARY_COLUMN_NAME);
-
-      String hostsStr;
-
-      if (useEmbeddedIgnite) {
-        Set<String> addrs = new HashSet<>();
-        cluster.cluster().nodes().forEach(clusterNode -> addrs.addAll(clusterNode.addresses()));
-        hostsStr = String.join(",", addrs);
-      } else {
-        hostsStr = hosts;
-      }
-
-      String url = "jdbc:ignite:thin://" + hostsStr;
-      try {
-        CONN.set(DriverManager.getConnection(url));
-      } catch (Exception e) {
-        throw new DBException(e);
-      }
     }
   }
 

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteJdbcClient.java
@@ -75,11 +75,17 @@ public class IgniteJdbcClient extends AbstractSqlClient {
   public void init() throws DBException {
     super.init();
 
-    String hosts = node.clusterNodes().stream()
-        .map(clusterNode -> clusterNode.address().toString().split(":")[0])
-        .collect(Collectors.joining(","));
+    String hostsStr = useEmbeddedIgnite ?
+        node.clusterNodes().stream()
+            .map(clusterNode -> clusterNode.address().host())
+            .collect(Collectors.joining(",")) :
+        hosts;
 
-    String url = "jdbc:ignite:thin://" + hosts;
+    //workaround for https://ggsystems.atlassian.net/browse/IGN-23887
+    //use only one cluster node address for connection
+    hostsStr = hostsStr.split(",")[0];
+
+    String url = "jdbc:ignite:thin://" + hostsStr;
     try {
       CONN.set(DriverManager.getConnection(url));
     } catch (Exception e) {


### PR DESCRIPTION
 - Workaround for [IGN-23887](https://ggsystems.atlassian.net/browse/IGN-23887) - use only one AI3/GG9 cluster node address when connect through JDBC thin client.
 - Fix JDBC connection initialization for AI2/GG8.

[IGN-23887]: https://ggsystems.atlassian.net/browse/IGN-23887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ