### PR TITLE
QA-4867 [YCSB] Support 'k', 'm' modifiers for recordcount, operationcount and other

### DIFF
--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -706,15 +706,7 @@ public final class Client {
    * Parse string (with possible modifiers: k=1000, and m=1000000) to int.
    */
   public static int parseIntWithModifiers(String value) {
-    if (value.endsWith("k") || value.endsWith("K")) {
-      return Integer.parseInt(value.substring(0, value.length() - 1)) * 1000;
-    }
-
-    if (value.endsWith("m") || value.endsWith("M")) {
-      return Integer.parseInt(value.substring(0, value.length() - 1)) * 1000000;
-    }
-
-    return Integer.parseInt(value);
+    return (int) parseLongWithModifiers(value);
   }
 
   /**
@@ -722,11 +714,11 @@ public final class Client {
    */
   public static long parseLongWithModifiers(String value) {
     if (value.endsWith("k") || value.endsWith("K")) {
-      return Long.parseLong(value.substring(0, value.length() - 1)) * 1000;
+      return (long) (Double.parseDouble(value.substring(0, value.length() - 1)) * 1000);
     }
 
     if (value.endsWith("m") || value.endsWith("M")) {
-      return Long.parseLong(value.substring(0, value.length() - 1)) * 1000000;
+      return (long) (Double.parseDouble(value.substring(0, value.length() - 1)) * 1000000);
     }
 
     return Long.parseLong(value);

--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -17,6 +17,8 @@
 
 package site.ycsb;
 
+import static site.ycsb.Workload.INSERT_COUNT_PROPERTY;
+
 import site.ycsb.measurements.Measurements;
 import site.ycsb.measurements.exporter.MeasurementsExporter;
 import site.ycsb.measurements.exporter.TextMeasurementsExporter;
@@ -136,13 +138,6 @@ public final class Client {
    * The number of YCSB client threads to run.
    */
   public static final String THREAD_COUNT_PROPERTY = "threadcount";
-
-  /**
-   * Indicates how many inserts to do if less than recordcount.
-   * Useful for partitioning the load among multiple servers if the client is the bottleneck.
-   * Additionally workloads should support the "insertstart" property which tells them which record to start at.
-   */
-  public static final String INSERT_COUNT_PROPERTY = "insertcount";
 
   /**
    * Target number of operations per second.
@@ -433,19 +428,19 @@ public final class Client {
     try (final TraceScope span = tracer.newScope(CLIENT_INIT_SPAN)) {
       int opcount;
       if (dotransactions) {
-        opcount = Integer.parseInt(props.getProperty(OPERATION_COUNT_PROPERTY, "0"));
+        opcount = parseIntWithModifiers(props.getProperty(OPERATION_COUNT_PROPERTY, "0"));
       } else {
         if (props.containsKey(INSERT_COUNT_PROPERTY)) {
-          opcount = Integer.parseInt(props.getProperty(INSERT_COUNT_PROPERTY, "0"));
+          opcount = parseIntWithModifiers(props.getProperty(INSERT_COUNT_PROPERTY, "0"));
         } else {
-          opcount = Integer.parseInt(props.getProperty(RECORD_COUNT_PROPERTY, DEFAULT_RECORD_COUNT));
+          opcount = parseIntWithModifiers(props.getProperty(RECORD_COUNT_PROPERTY, DEFAULT_RECORD_COUNT));
         }
       }
       if (threadcount > opcount && opcount > 0){
         threadcount = opcount;
         System.out.println("Warning: the threadcount is bigger than recordcount, the threadcount will be recordcount!");
       }
-      int warmupops = Integer.parseInt(props.getProperty(WARM_UP_OPERATIONS_COUNT_PROPERTY, DEFAULT_WARMUP_OPS));
+      int warmupops = parseIntWithModifiers(props.getProperty(WARM_UP_OPERATIONS_COUNT_PROPERTY, DEFAULT_WARMUP_OPS));
       for (int threadid = 0; threadid < threadcount; threadid++) {
         int threadopcount = opcount / threadcount;
         int threadwarmupopcount = warmupops / threadcount;
@@ -705,5 +700,35 @@ public final class Client {
     }
 
     return props;
+  }
+
+  /**
+   * Parse string (with possible modifiers: k=1000, and m=1000000) to int.
+   */
+  public static int parseIntWithModifiers(String value) {
+    if (value.endsWith("k")) {
+      return Integer.parseInt(value.substring(0, value.length() - 1)) * 1000;
+    }
+
+    if (value.endsWith("m")) {
+      return Integer.parseInt(value.substring(0, value.length() - 1)) * 1000000;
+    }
+
+    return Integer.parseInt(value);
+  }
+
+  /**
+   * Parse string (with possible modifiers: k=1000, and m=1000000) to long.
+   */
+  public static long parseLongWithModifiers(String value) {
+    if (value.endsWith("k")) {
+      return Long.parseLong(value.substring(0, value.length() - 1)) * 1000;
+    }
+
+    if (value.endsWith("m")) {
+      return Long.parseLong(value.substring(0, value.length() - 1)) * 1000000;
+    }
+
+    return Long.parseLong(value);
   }
 }

--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -706,11 +706,11 @@ public final class Client {
    * Parse string (with possible modifiers: k=1000, and m=1000000) to int.
    */
   public static int parseIntWithModifiers(String value) {
-    if (value.endsWith("k")) {
+    if (value.endsWith("k") || value.endsWith("K")) {
       return Integer.parseInt(value.substring(0, value.length() - 1)) * 1000;
     }
 
-    if (value.endsWith("m")) {
+    if (value.endsWith("m") || value.endsWith("M")) {
       return Integer.parseInt(value.substring(0, value.length() - 1)) * 1000000;
     }
 
@@ -721,11 +721,11 @@ public final class Client {
    * Parse string (with possible modifiers: k=1000, and m=1000000) to long.
    */
   public static long parseLongWithModifiers(String value) {
-    if (value.endsWith("k")) {
+    if (value.endsWith("k") || value.endsWith("K")) {
       return Long.parseLong(value.substring(0, value.length() - 1)) * 1000;
     }
 
-    if (value.endsWith("m")) {
+    if (value.endsWith("m") || value.endsWith("M")) {
       return Long.parseLong(value.substring(0, value.length() - 1)) * 1000000;
     }
 

--- a/core/src/main/java/site/ycsb/DBWrapper.java
+++ b/core/src/main/java/site/ycsb/DBWrapper.java
@@ -19,6 +19,7 @@ package site.ycsb;
 
 import static site.ycsb.Client.BATCH_SIZE_PROPERTY;
 import static site.ycsb.Client.DEFAULT_BATCH_SIZE;
+import static site.ycsb.Client.parseIntWithModifiers;
 
 import java.util.Map;
 
@@ -117,7 +118,7 @@ public class DBWrapper extends DB {
             " for latency are: " + this.latencyTrackedErrors.toString());
       }
 
-      batchSize = Integer.parseInt(getProperties().getProperty(BATCH_SIZE_PROPERTY, DEFAULT_BATCH_SIZE));
+      batchSize = parseIntWithModifiers(getProperties().getProperty(BATCH_SIZE_PROPERTY, DEFAULT_BATCH_SIZE));
       threadWarmUpOpsCount = threadWarmUpOpsCount / batchSize;
     }
   }

--- a/core/src/main/java/site/ycsb/Workload.java
+++ b/core/src/main/java/site/ycsb/Workload.java
@@ -36,7 +36,17 @@ import java.util.Properties;
  * client how many inserts to do. In the example above, both clients should have insertcount=500000.
  */
 public abstract class Workload {
+  /**
+   * Indicates which record to start at when do inserts.
+   * Useful for partitioning the load among multiple servers if the client is the bottleneck.
+   */
   public static final String INSERT_START_PROPERTY = "insertstart";
+
+  /**
+   * Indicates how many inserts to do if less than recordcount.
+   * Useful for partitioning the load among multiple servers if the client is the bottleneck.
+   * Support the "insertstart" property which tells them which record to start at.
+   */
   public static final String INSERT_COUNT_PROPERTY = "insertcount";
   
   public static final String INSERT_START_PROPERTY_DEFAULT = "0";

--- a/core/src/main/java/site/ycsb/workloads/ConstantOccupancyWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/ConstantOccupancyWorkload.java
@@ -17,6 +17,7 @@
 package site.ycsb.workloads;
 
 import site.ycsb.Client;
+import site.ycsb.Workload;
 import site.ycsb.WorkloadException;
 import site.ycsb.generator.NumberGenerator;
 
@@ -65,7 +66,7 @@ public class ConstantOccupancyWorkload extends CoreWorkload {
     occupancy = Double.parseDouble(p.getProperty(OCCUPANCY_PROPERTY, String.valueOf(OCCUPANCY_PROPERTY_DEFAULT)));
 
     if (p.getProperty(Client.RECORD_COUNT_PROPERTY) != null ||
-        p.getProperty(Client.INSERT_COUNT_PROPERTY) != null ||
+        p.getProperty(Workload.INSERT_COUNT_PROPERTY) != null ||
         p.getProperty(Client.OPERATION_COUNT_PROPERTY) != null) {
       System.err.println("Warning: record, insert or operation count was set prior to initting " +
           "ConstantOccupancyWorkload.  Overriding old values.");
@@ -80,7 +81,7 @@ public class ConstantOccupancyWorkload extends CoreWorkload {
     }
     p.setProperty(Client.RECORD_COUNT_PROPERTY, String.valueOf(objectCount));
     p.setProperty(Client.OPERATION_COUNT_PROPERTY, String.valueOf(storageages * objectCount));
-    p.setProperty(Client.INSERT_COUNT_PROPERTY, String.valueOf(objectCount));
+    p.setProperty(Workload.INSERT_COUNT_PROPERTY, String.valueOf(objectCount));
 
     super.init(p);
   }

--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -19,6 +19,8 @@ package site.ycsb.workloads;
 
 import static site.ycsb.Client.DEFAULT_WARMUP_OPS;
 import static site.ycsb.Client.WARM_UP_OPERATIONS_COUNT_PROPERTY;
+import static site.ycsb.Client.parseIntWithModifiers;
+import static site.ycsb.Client.parseLongWithModifiers;
 
 import java.util.concurrent.atomic.AtomicLong;
 import site.ycsb.*;
@@ -448,13 +450,13 @@ public class CoreWorkload extends Workload {
     fieldlengthgenerator = CoreWorkload.getFieldLengthGenerator(p);
 
     warmupops =
-        Long.parseLong(p.getProperty(WARM_UP_OPERATIONS_COUNT_PROPERTY, DEFAULT_WARMUP_OPS));
+        parseLongWithModifiers(p.getProperty(WARM_UP_OPERATIONS_COUNT_PROPERTY, DEFAULT_WARMUP_OPS));
     if (warmupops < 0) {
       System.err.println("Invalid warmupops=" + warmupops + ". warmupops must not be negative.");
       System.exit(-1);
     }
     recordcount =
-        Long.parseLong(p.getProperty(Client.RECORD_COUNT_PROPERTY, Client.DEFAULT_RECORD_COUNT));
+        parseLongWithModifiers(p.getProperty(Client.RECORD_COUNT_PROPERTY, Client.DEFAULT_RECORD_COUNT));
     if (recordcount == 0) {
       recordcount = Integer.MAX_VALUE;
     }
@@ -463,7 +465,7 @@ public class CoreWorkload extends Workload {
     int threads = Integer.parseInt(p.getProperty(Client.THREAD_COUNT_PROPERTY, "1"));
 
     batchsize =
-        Integer.parseInt(p.getProperty(Client.BATCH_SIZE_PROPERTY, Client.DEFAULT_BATCH_SIZE));
+        parseIntWithModifiers(p.getProperty(Client.BATCH_SIZE_PROPERTY, Client.DEFAULT_BATCH_SIZE));
     if (batchsize < 1) {
       System.err.println("Invalid batchsize=" + batchsize + ". batchsize must be bigger than 0.");
       System.exit(-1);
@@ -490,9 +492,9 @@ public class CoreWorkload extends Workload {
         p.getProperty(SCAN_LENGTH_DISTRIBUTION_PROPERTY, SCAN_LENGTH_DISTRIBUTION_PROPERTY_DEFAULT);
 
     long insertstart =
-        Long.parseLong(p.getProperty(INSERT_START_PROPERTY, INSERT_START_PROPERTY_DEFAULT));
+        parseLongWithModifiers(p.getProperty(INSERT_START_PROPERTY, INSERT_START_PROPERTY_DEFAULT));
     long insertcount=
-        Integer.parseInt(p.getProperty(INSERT_COUNT_PROPERTY, String.valueOf(recordcount - insertstart)));
+        parseLongWithModifiers(p.getProperty(INSERT_COUNT_PROPERTY, String.valueOf(recordcount - insertstart)));
     // Confirm valid values for insertstart and insertcount in relation to recordcount
     if (recordcount < (insertstart + insertcount)) {
       System.err.println("Invalid combination of insertstart, insertcount and recordcount.");
@@ -552,7 +554,7 @@ public class CoreWorkload extends Workload {
       // the keyspace doesn't change from the perspective of the scrambled zipfian generator
       final double insertproportion = Double.parseDouble(
           p.getProperty(INSERT_PROPORTION_PROPERTY, INSERT_PROPORTION_PROPERTY_DEFAULT));
-      int opcount = Integer.parseInt(p.getProperty(Client.OPERATION_COUNT_PROPERTY));
+      int opcount = parseIntWithModifiers(p.getProperty(Client.OPERATION_COUNT_PROPERTY));
       int expectednewkeys = (int) ((opcount) * insertproportion * 2.0); // 2 is fudge factor
 
       keychooser = new ScrambledZipfianGenerator(insertstart, insertstart + insertcount + expectednewkeys);

--- a/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
@@ -16,6 +16,8 @@
  */
 package site.ycsb.workloads;
 
+import static site.ycsb.Client.parseIntWithModifiers;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -545,7 +547,7 @@ public class TimeSeriesWorkload extends Workload {
   public void init(final Properties p) throws WorkloadException {
     properties = p;
     recordcount =
-        Integer.parseInt(p.getProperty(Client.RECORD_COUNT_PROPERTY, 
+        parseIntWithModifiers(p.getProperty(Client.RECORD_COUNT_PROPERTY,
             Client.DEFAULT_RECORD_COUNT));
     if (recordcount == 0) {
       recordcount = Integer.MAX_VALUE;

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
@@ -17,6 +17,8 @@
 
 package site.ycsb.db.ignite3;
 
+import static site.ycsb.Client.parseLongWithModifiers;
+
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -178,9 +180,9 @@ public abstract class IgniteAbstractClient extends DB {
             CoreWorkload.FIELD_COUNT_PROPERTY, CoreWorkload.FIELD_COUNT_PROPERTY_DEFAULT));
         fieldPrefix = getProperties().getProperty(CoreWorkload.FIELD_NAME_PREFIX,
             CoreWorkload.FIELD_NAME_PREFIX_DEFAULT);
-        recordsCount = Long.parseLong(getProperties().getProperty(Client.RECORD_COUNT_PROPERTY,
+        recordsCount = parseLongWithModifiers(getProperties().getProperty(Client.RECORD_COUNT_PROPERTY,
             Client.DEFAULT_RECORD_COUNT));
-        batchSize = Long.parseLong(getProperties().getProperty(Client.BATCH_SIZE_PROPERTY,
+        batchSize = parseLongWithModifiers(getProperties().getProperty(Client.BATCH_SIZE_PROPERTY,
             Client.DEFAULT_BATCH_SIZE));
 
         for (int i = 0; i < fieldCount; i++) {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/QA-4867

Example of local run: https://ward.gridgain.com/tests/663392216309fe0ea14e4cf9