### PR TITLE
QA-4730 [YCSB][AI3] Rework batch runs with multi-threaded mode

### DIFF
--- a/core/src/main/java/site/ycsb/DBWrapper.java
+++ b/core/src/main/java/site/ycsb/DBWrapper.java
@@ -49,12 +49,16 @@ public class DBWrapper extends DB {
 
   private static final AtomicBoolean LOG_REPORT_CONFIG = new AtomicBoolean(false);
 
+  /** Number of batch operations performed. */
   private long batchOpsDone = 0L;
 
+  /** Number of warm-up operations to perform (records to process). */
   private int warmUpOpsCount;
 
+  /** Number of batch warm-up operations to perform. */
   private int warmUpBatchOps;
 
+  /** Batch size. */
   private int batchSize;
 
   private final String scopeStringCleanup;

--- a/core/src/main/java/site/ycsb/measurements/OneMeasurementTimeSeries.java
+++ b/core/src/main/java/site/ycsb/measurements/OneMeasurementTimeSeries.java
@@ -106,7 +106,7 @@ public class OneMeasurementTimeSeries extends OneMeasurement {
   }
 
   @Override
-  public void measure(int latency) {
+  public synchronized void measure(int latency) {
     checkEndOfUnit(false);
 
     histogram.recordValue(latency);


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/QA-4730

- fix `isWarmUpDone()` for `DBWrapper`
- made `measure()` synchronized for OneMeasurementTimeSeries as it is already done for other types of measurements.
