### PR TITLE
QA-5274 Split 'warmup' and 'payload' stats

### DIFF
--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -255,8 +255,8 @@ public final class Client {
       long warmupRuntime = warmupEnd - warmupStart;
       long payloadRuntime = payloadEnd - payloadStart;
       long overallRuntime = warmupRuntime + payloadRuntime;
-      double warmupThroughput = 1000.0 * (warmupOpsCount) / (warmupRuntime);
-      double payloadThroughput = 1000.0 * (payloadOpsCount) / (payloadRuntime);
+      double warmupThroughput = 1000d * warmupOpsCount / warmupRuntime;
+      double payloadThroughput = 1000d * payloadOpsCount / payloadRuntime;
 
       exporter.write("WARM-UP", "StartTime(ms)", warmupStart);
       exporter.write("WARM-UP", "RunTime(ms)", warmupRuntime);

--- a/core/src/main/java/site/ycsb/ClientThread.java
+++ b/core/src/main/java/site/ycsb/ClientThread.java
@@ -38,6 +38,7 @@ public class ClientThread implements Runnable {
   private int warmupopscount;
   private int totalopscount;
   private double targetOpsPerMs;
+  private long warmupEnd = System.currentTimeMillis();
   private long payloadStart = 0;
 
   private int payloadopsdone;
@@ -118,6 +119,10 @@ public class ClientThread implements Runnable {
     return warmupopsdone >= warmupopscount;
   }
 
+  public long getWarmupEnd() {
+    return warmupEnd;
+  }
+
   public long getPayloadStart() {
     return payloadStart;
   }
@@ -162,7 +167,8 @@ public class ClientThread implements Runnable {
 
           if (isWarmUpDone()) {
             if (payloadStart == 0) {
-              payloadStart = System.currentTimeMillis();
+              warmupEnd = System.currentTimeMillis();
+              payloadStart = warmupEnd;
             }
             payloadopsdone++;
           } else {
@@ -184,7 +190,8 @@ public class ClientThread implements Runnable {
 
           if (isWarmUpDone()) {
             if (payloadStart == 0) {
-              payloadStart = System.currentTimeMillis();
+              warmupEnd = System.currentTimeMillis();
+              payloadStart = warmupEnd;
             }
             payloadopsdone++;
           } else {

--- a/core/src/main/java/site/ycsb/StatusThread.java
+++ b/core/src/main/java/site/ycsb/StatusThread.java
@@ -166,8 +166,15 @@ public class StatusThread extends Thread {
     DecimalFormat d = new DecimalFormat("#.##");
     String labelString = this.label + format.format(new Date());
 
-    StringBuilder msg = new StringBuilder(labelString).append(iswarmupdone ? " [PAYLOAD] " : " [WARM-UP] ")
-        .append(interval / 1000).append(" sec: ");
+    StringBuilder msg = new StringBuilder(labelString);
+
+    if (totalops > 0) {
+      msg.append(iswarmupdone ? " [PAYLOAD] " : " [WARM-UP] ");
+    } else {
+      msg.append(" [SETUP] ");
+    }
+
+    msg.append(interval / 1000).append(" sec: ");
     msg.append(totalops).append(" operations; ");
 
     if (totalops != 0) {


### PR DESCRIPTION
- Split `[WARM-UP]` and `[PAYLOAD]` stats
- Print `startTime(ms)` to result stats
- Print `[SETUP]` status when no operations done yet