### PR TITLE
QA-6025 Set fixed length of 'varchar' fields

### DIFF
--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -151,6 +151,16 @@ public class CoreWorkload extends Workload {
   public static final String MIN_FIELD_LENGTH_PROPERTY_DEFAULT = "1";
 
   /**
+   * The name of the property for using VARCHAR type with limit.
+   */
+  public static final String USE_LIMITED_VARCHAR_PROPERTY = "uselimitedvarchar";
+
+  /**
+   * The default option for using VARCHAR type with limit.
+   */
+  public static final String USE_LIMITED_VARCHAR_PROPERTY_DEFAULT = "true";
+
+  /**
    * The name of a property that specifies the filename containing the field length histogram (only
    * used if fieldlengthdistribution is "histogram").
    */

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
@@ -92,6 +92,8 @@ public abstract class IgniteAbstractClient extends DB {
 
   protected String fieldPrefix;
 
+  protected boolean useLimitedVarchar;
+
   protected long recordsCount;
 
   protected long batchSize;
@@ -283,6 +285,8 @@ public abstract class IgniteAbstractClient extends DB {
           CoreWorkload.FIELD_LENGTH_PROPERTY, CoreWorkload.FIELD_LENGTH_PROPERTY_DEFAULT));
       fieldPrefix = properties.getProperty(
           CoreWorkload.FIELD_NAME_PREFIX, CoreWorkload.FIELD_NAME_PREFIX_DEFAULT);
+      useLimitedVarchar = Boolean.parseBoolean(properties.getProperty(
+          CoreWorkload.USE_LIMITED_VARCHAR_PROPERTY, CoreWorkload.USE_LIMITED_VARCHAR_PROPERTY_DEFAULT));
       indexCount = Integer.parseInt(properties.getProperty(
           CoreWorkload.INDEX_COUNT_PROPERTY, CoreWorkload.INDEX_COUNT_PROPERTY_DEFAULT));
       indexType = properties.getProperty(CoreWorkload.INDEX_TYPE_PROPERTY, "");
@@ -404,7 +408,9 @@ public abstract class IgniteAbstractClient extends DB {
    * Prepare the creation table SQL line(s).
    */
   public List<String> createTablesSQL() {
-    String fieldType = String.format(" VARCHAR(%s)", fieldLength);
+    String fieldType = useLimitedVarchar
+        ? String.format(" VARCHAR(%s)", fieldLength)
+        : " VARCHAR";
 
     String fieldsSpecs = valueFields.stream()
         .map(e -> e + fieldType)

--- a/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
+++ b/ignite3/src/main/java/site/ycsb/db/ignite3/IgniteAbstractClient.java
@@ -84,6 +84,8 @@ public abstract class IgniteAbstractClient extends DB {
 
   protected int fieldCount;
 
+  protected int fieldLength;
+
   protected int indexCount;
 
   protected String indexType;
@@ -277,6 +279,8 @@ public abstract class IgniteAbstractClient extends DB {
           CoreWorkload.TABLENAME_PROPERTY, CoreWorkload.TABLENAME_PROPERTY_DEFAULT);
       fieldCount = Integer.parseInt(properties.getProperty(
           CoreWorkload.FIELD_COUNT_PROPERTY, CoreWorkload.FIELD_COUNT_PROPERTY_DEFAULT));
+      fieldLength = Integer.parseInt(properties.getProperty(
+          CoreWorkload.FIELD_LENGTH_PROPERTY, CoreWorkload.FIELD_LENGTH_PROPERTY_DEFAULT));
       fieldPrefix = properties.getProperty(
           CoreWorkload.FIELD_NAME_PREFIX, CoreWorkload.FIELD_NAME_PREFIX_DEFAULT);
       indexCount = Integer.parseInt(properties.getProperty(
@@ -400,8 +404,10 @@ public abstract class IgniteAbstractClient extends DB {
    * Prepare the creation table SQL line(s).
    */
   public List<String> createTablesSQL() {
+    String fieldType = String.format(" VARCHAR(%s)", fieldLength);
+
     String fieldsSpecs = valueFields.stream()
-        .map(e -> e + " VARCHAR")
+        .map(e -> e + fieldType)
         .collect(Collectors.joining(", "));
 
     String withZoneName = "";


### PR DESCRIPTION
- set fixed length of 'varchar' fields based on new `uselimitedvarchar` property

Test runs of KV throughput with indexes:
- [1 replicas, uselimitedvarchar=true](https://ggtc.gridgain.com/buildConfiguration/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES/14633479) | [kv_load.txt](https://ggtc.gridgain.com/repository/download/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES/14633479:id/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES-25-9.1.127-SNAPSHOT.zip!/log/ycsb/2025-06-04-08-03-51_172.25.4.49_kv_load.txt)
- [1 replicas, uselimitedvarchar=false](https://ggtc.gridgain.com/buildConfiguration/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES/14633506) | [kv_load.txt](https://ggtc.gridgain.com/repository/download/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES/14633506:id/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES-27-9.1.127-SNAPSHOT.zip!/log/ycsb/2025-06-04-08-30-40_172.25.4.49_kv_load.txt)
- [3 replicas, uselimitedvarchar=true](https://ggtc.gridgain.com/buildConfiguration/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES_REPLICAS3/14633483) | [kv_load.txt](https://ggtc.gridgain.com/repository/download/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES_REPLICAS3/14633483:id/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES_REPLICAS3-13-9.1.127-SNAPSHOT.zip!/log/ycsb/2025-06-04-08-17-32_172.25.4.49_kv_load.txt)
- [3 replicas, uselimitedvarchar=false](https://ggtc.gridgain.com/buildConfiguration/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES_REPLICAS3/14633485) | [kv_load.txt](https://ggtc.gridgain.com/repository/download/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES_REPLICAS3/14633485:id/Qa_Gg9BenchmarksLab_YCSB_KV_THROUGHPUT_WITH_INDEXES_REPLICAS3-14-9.1.127-SNAPSHOT.zip!/log/ycsb/2025-06-04-08-40-02_172.25.4.49_kv_load.txt)