### PR TITLE
QA-6237 [YCSB] Add standard deviation to the result measurements

### DIFF
--- a/core/src/main/java/site/ycsb/measurements/OneMeasurementHdrHistogram.java
+++ b/core/src/main/java/site/ycsb/measurements/OneMeasurementHdrHistogram.java
@@ -114,7 +114,8 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
       log.close();
     }
     exporter.write(getName(), "Operations", totalHistogram.getTotalCount());
-    exporter.write(getName(), "AverageLatency(us)", totalHistogram.getMean());
+    exporter.write(getName(), "AvgLatency(us)", totalHistogram.getMean());
+    exporter.write(getName(), "StdDevLatency(us)", totalHistogram.getStdDeviation());
     exporter.write(getName(), "MinLatency(us)", totalHistogram.getMinValue());
     exporter.write(getName(), "MaxLatency(us)", totalHistogram.getMaxValue());
 
@@ -156,12 +157,16 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
     }
 
     DecimalFormat d = new DecimalFormat("#.##");
-    return "[" + getName() + ": Count=" + intervalHistogram.getTotalCount() + ", Max="
-        + intervalHistogram.getMaxValue() + ", Min=" + intervalHistogram.getMinValue() + ", Avg="
-        + d.format(intervalHistogram.getMean()) + ", 90=" + d.format(intervalHistogram.getValueAtPercentile(90))
-        + ", 99=" + d.format(intervalHistogram.getValueAtPercentile(99)) + ", 99.9="
-        + d.format(intervalHistogram.getValueAtPercentile(99.9)) + ", 99.99="
-        + d.format(intervalHistogram.getValueAtPercentile(99.99)) + "]";
+    return "[" + getName() + ": "
+        + "Count=" + intervalHistogram.getTotalCount() + ", "
+        + "Max=" + intervalHistogram.getMaxValue() + ", "
+        + "Min=" + intervalHistogram.getMinValue() + ", "
+        + "Avg=" + d.format(intervalHistogram.getMean()) + ", "
+        + "StdDev=" + d.format(intervalHistogram.getStdDeviation()) + ", "
+        + "90=" + d.format(intervalHistogram.getValueAtPercentile(90)) + ", "
+        + "99=" + d.format(intervalHistogram.getValueAtPercentile(99)) + ", "
+        + "99.9=" + d.format(intervalHistogram.getValueAtPercentile(99.9)) + ", "
+        + "99.99=" + d.format(intervalHistogram.getValueAtPercentile(99.99)) + "]";
   }
 
   private Histogram getIntervalHistogramAndAccumulate() {

--- a/core/src/main/java/site/ycsb/measurements/OneMeasurementTimeSeries.java
+++ b/core/src/main/java/site/ycsb/measurements/OneMeasurementTimeSeries.java
@@ -17,14 +17,14 @@
 
 package site.ycsb.measurements;
 
-import java.util.ArrayList;
-import java.util.List;
+import site.ycsb.measurements.exporter.MeasurementsExporter;
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.Recorder;
-import site.ycsb.measurements.exporter.MeasurementsExporter;
 
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
 
@@ -134,10 +134,11 @@ public class OneMeasurementTimeSeries extends OneMeasurement {
     // accumulate the last interval which was not caught by status thread
     Histogram intervalHistogram = getIntervalHistogramAndAccumulate();
 
-    exporter.write(getName(), "Operations", operations);
-    exporter.write(getName(), "AverageLatency(us)", (((double) totallatency) / ((double) operations)));
-    exporter.write(getName(), "MinLatency(us)", min);
-    exporter.write(getName(), "MaxLatency(us)", max);
+    exporter.write(getName(), "Operations", totalHistogram.getTotalCount());
+    exporter.write(getName(), "AvgLatency(us)", totalHistogram.getMean());
+    exporter.write(getName(), "StdDevLatency(us)", totalHistogram.getStdDeviation());
+    exporter.write(getName(), "MinLatency(us)", totalHistogram.getMinValue());
+    exporter.write(getName(), "MaxLatency(us)", totalHistogram.getMaxValue());
 
     for (Double percentile : percentiles) {
       exporter.write(getName(), ordinal(percentile) + "PercentileLatency(us)",


### PR DESCRIPTION
Test run:
✔️ [AI3](https://ggtc.gridgain.com/buildConfiguration/Qa_Ai3BenchmarksLab_YCSB_KV_THROUGHPUT/14840881)
✔️ [GG8](https://ggtc.gridgain.com/buildConfiguration/Qa_Gg8BenchmarksLab_YCSB_KV_THROUGHPUT/14839760)

[Log example AI3](https://ggtc.gridgain.com/repository/download/Qa_Ai3BenchmarksLab_YCSB_KV_THROUGHPUT/14840881:id/Qa_Ai3BenchmarksLab_YCSB_KV_THROUGHPUT-44-9.1.127-SNAPSHOT.zip!/log/ycsb/2025-06-24-08-44-53_172.25.4.49_kv_load.txt):
```
[INSERT], Operations, 7500000
[INSERT], AvgLatency(us), 662.3050678666667
[INSERT], StdDevLatency(us), 2265.689794255308
[INSERT], MinLatency(us), 139
[INSERT], MaxLatency(us), 202879
[INSERT], 95thPercentileLatency(us), 1245
[INSERT], 99thPercentileLatency(us), 2409
```

[Log example GG8](https://ggtc.gridgain.com/repository/download/Qa_Gg8BenchmarksLab_YCSB_KV_THROUGHPUT/14839760:id/Qa_Gg8BenchmarksLab_YCSB_KV_THROUGHPUT-10-8.9.21.zip!/log/ycsb/2025-06-24-07-37-56_172.25.4.49_kv_load.txt):
```
[INSERT], Operations, 7500000
[INSERT], AvgLatency(us), 751.46482
[INSERT], StdDevLatency(us), 3161.6047600510265
[INSERT], MinLatency(us), 142
[INSERT], MaxLatency(us), 323327
[INSERT], 95thPercentileLatency(us), 1358
[INSERT], 99thPercentileLatency(us), 415
```