### PR TITLE
QA-6887 Fix the target parameter usage

### DIFF
--- a/core/src/main/java/site/ycsb/ClientThread.java
+++ b/core/src/main/java/site/ycsb/ClientThread.java
@@ -149,10 +149,8 @@ public class ClientThread implements Runnable {
     // and the client thread have the same view on time.
 
     //spread the thread operations out so they don't all hit the DB at the same time
-    // GH issue 4 - throws exception if _target>1 because random.nextInt argument must be >0
-    // and the sleep() doesn't make sense for granularities < 1 ms anyway
     if ((targetOpsPerMs > 0) && (targetOpsPerMs <= 1.0)) {
-      long randomMinorDelay = ThreadLocalRandom.current().nextInt((int) targetOpsTickNs);
+      long randomMinorDelay = ThreadLocalRandom.current().nextLong(targetOpsTickNs);
       sleepUntil(System.nanoTime() + randomMinorDelay);
     }
     try {


### PR DESCRIPTION
**Test runs:**
✔️ [#7974](https://ggtc.gridgain.com/buildConfiguration/Qa_PocBenchmarkAwsSourcesAi3BuildType/17401053) - target=1000 ([load log](https://ggtc.gridgain.com/repository/download/Qa_PocBenchmarkAwsSourcesAi3BuildType/17401053:id/Qa_PocBenchmarkAwsSourcesAi3BuildType-7974-3.2.0-SNAPSHOT.zip!/log-2026-01-16-08-50-38/other/192.168.208.57/ycsb/2026-01-16-08-47-46_192.168.208.57_kv_load.txt) | [run log](https://ggtc.gridgain.com/repository/download/Qa_PocBenchmarkAwsSourcesAi3BuildType/17401053:id/Qa_PocBenchmarkAwsSourcesAi3BuildType-7974-3.2.0-SNAPSHOT.zip!/log-2026-01-16-08-50-38/other/192.168.208.57/ycsb/2026-01-16-08-48-32_192.168.208.57_kv_run.txt))
✔️ [#7975](https://ggtc.gridgain.com/buildConfiguration/Qa_PocBenchmarkAwsSourcesAi3BuildType/17401055) - target=10000 ([load log](https://ggtc.gridgain.com/repository/download/Qa_PocBenchmarkAwsSourcesAi3BuildType/17401055:id/Qa_PocBenchmarkAwsSourcesAi3BuildType-7975-3.2.0-SNAPSHOT.zip!/log-2026-01-16-08-50-36/other/192.168.208.125/ycsb/2026-01-16-08-47-49_192.168.208.125_kv_load.txt) | [run log](https://ggtc.gridgain.com/repository/download/Qa_PocBenchmarkAwsSourcesAi3BuildType/17401055:id/Qa_PocBenchmarkAwsSourcesAi3BuildType-7975-3.2.0-SNAPSHOT.zip!/log-2026-01-16-08-50-36/other/192.168.208.125/ycsb/2026-01-16-08-48-30_192.168.208.125_kv_run.txt))